### PR TITLE
Pinned version of FESTIM

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,4 +13,4 @@ dependencies:
   - nbconvert
   - ipykernel  # needed to run jupyter notebooks
   - pip:
-    - festim
+    - festim=1.3

--- a/environment.yml
+++ b/environment.yml
@@ -13,4 +13,4 @@ dependencies:
   - nbconvert
   - ipykernel  # needed to run jupyter notebooks
   - pip:
-    - festim=1.3
+    - festim==1.3


### PR DESCRIPTION
We should use a pinned version of FESTIM instead. Otherwise, this environment will pick up the latest version.

This means that if we release a breaking change in 1.4 for instance, then this repo will "break".